### PR TITLE
feat: handle partial state objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,9 @@
 	],
 	"dependencies": {
 		"atem-connection": "2.2.2",
-		"tslib": "^2.2.0"
+		"deepmerge": "^4.2.2",
+		"tslib": "^2.2.0",
+		"type-fest": "^1.0.2"
 	},
 	"standard-version": {
 		"message": "chore(release): %s [skip ci]",

--- a/src/__tests__/atemState.spec.ts
+++ b/src/__tests__/atemState.spec.ts
@@ -1,5 +1,5 @@
-import { AtemState } from '../state'
 import { AtemStateUtil } from 'atem-connection'
+import { AtemState } from '../atemState'
 
 test('Unit test: Atem State: Set State', function () {
 	const state = new AtemState()

--- a/src/__tests__/atemState.spec.ts
+++ b/src/__tests__/atemState.spec.ts
@@ -1,4 +1,4 @@
-import { AtemState } from '../'
+import { AtemState } from '../state'
 import { AtemStateUtil } from 'atem-connection'
 
 test('Unit test: Atem State: Set State', function () {

--- a/src/__tests__/enums.spec.ts
+++ b/src/__tests__/enums.spec.ts
@@ -1,4 +1,4 @@
-import { Enums } from '../'
+import * as Enums from '../enums'
 import { Enums as ConnEnums } from 'atem-connection'
 
 function getNumberValues(obj: any): number[] {

--- a/src/atemState.ts
+++ b/src/atemState.ts
@@ -1,5 +1,5 @@
 import { Commands, Enums, AtemStateUtil } from 'atem-connection'
-import { State as StateObject } from '.'
+import { State as StateObject } from './state'
 import * as Resolvers from './resolvers'
 
 export class AtemState {

--- a/src/defaults/video.ts
+++ b/src/defaults/video.ts
@@ -104,10 +104,34 @@ export const WipeTransitionSettings: VideoState.WipeTransitionSettings = {
 	flipFlop: false,
 }
 
-// export const TransitionProperties: Omit<VideoState.TransitionProperties, 'nextStyle' | 'nextSelection'> = {
-// 	style: Enums.TransitionStyle.MIX,
-// 	selection: 1
-// }
+export const TransitionProperties: VideoState.TransitionProperties = {
+	style: Enums.TransitionStyle.MIX,
+	selection: 1,
+	nextStyle: Enums.TransitionStyle.MIX,
+	nextSelection: 1,
+}
+
+export const UpstreamKeyerMask: VideoState.USK.UpstreamKeyerMaskSettings = {
+	maskEnabled: false,
+	maskTop: 0,
+	maskBottom: 0,
+	maskLeft: 0,
+	maskRight: 0,
+}
+
+export function UpstreamKeyer(id: number): VideoState.USK.UpstreamKeyer {
+	return {
+		upstreamKeyerId: id,
+		mixEffectKeyType: Enums.MixEffectKeyType.Luma,
+		flyEnabled: false,
+		flyKeyframes: [undefined, undefined],
+		canFlyKey: false,
+		fillSource: 0,
+		cutSource: 0,
+		maskSettings: UpstreamKeyerMask,
+		onAir: false,
+	}
+}
 
 export const UpstreamKeyerPatternSettings: VideoState.USK.UpstreamKeyerPatternSettings = {
 	style: Enums.Pattern.LeftToRightBar,

--- a/src/defaults/video.ts
+++ b/src/defaults/video.ts
@@ -42,6 +42,16 @@ export const DownstreamerKeyerProperties: Readonly<VideoState.DSK.DownstreamKeye
 	},
 }
 
+export const DownstreamKeyer: Readonly<VideoState.DSK.DownstreamKeyer> = {
+	properties: DownstreamerKeyerProperties,
+	sources: DownstreamerKeyerSources,
+
+	inTransition: false,
+	remainingFrames: 0,
+	isAuto: false,
+	onAir: false,
+}
+
 export const DipTransitionSettings: VideoState.DipTransitionSettings = {
 	rate: defaultRate,
 	input: defaultInput,

--- a/src/resolvers/__tests__/downstreamKeyer.spec.ts
+++ b/src/resolvers/__tests__/downstreamKeyer.spec.ts
@@ -5,8 +5,8 @@ import { Commands, AtemStateUtil, AtemState, VideoState } from 'atem-connection'
 import * as Defaults from '../../defaults'
 import { jsonClone } from '../../util'
 
-function setupDSK(state: StateObject, index: number, props?: Partial<VideoState.DSK.DownstreamKeyer>) {
-	const dsk = AtemStateUtil.getDownstreamKeyer(state as AtemState, index)
+function setupDSK(state: PartialDeep<StateObject>, index: number, props?: Partial<VideoState.DSK.DownstreamKeyer>) {
+	const dsk = AtemStateUtil.getDownstreamKeyer(state, index)
 	dsk.properties = jsonClone({
 		...Defaults.Video.DownstreamerKeyerProperties,
 		...props,

--- a/src/resolvers/__tests__/downstreamKeyer.spec.ts
+++ b/src/resolvers/__tests__/downstreamKeyer.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import * as DSK from '../downstreamKeyer'
-import { State as StateObject } from '../../'
+import { State as StateObject } from '../../state'
 import { Commands, AtemStateUtil, VideoState, AtemState } from 'atem-connection'
 import * as Defaults from '../../defaults'
 import { jsonClone } from '../../util'

--- a/src/resolvers/__tests__/downstreamKeyer.spec.ts
+++ b/src/resolvers/__tests__/downstreamKeyer.spec.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import * as DSK from '../downstreamKeyer'
 import { State as StateObject } from '../../'
-import { Commands, AtemStateUtil, AtemState, VideoState } from 'atem-connection'
+import { Commands, AtemStateUtil, VideoState, AtemState } from 'atem-connection'
 import * as Defaults from '../../defaults'
 import { jsonClone } from '../../util'
 
-function setupDSK(state: PartialDeep<StateObject>, index: number, props?: Partial<VideoState.DSK.DownstreamKeyer>) {
-	const dsk = AtemStateUtil.getDownstreamKeyer(state, index)
+function setupDSK(state: StateObject, index: number, props?: Partial<VideoState.DSK.DownstreamKeyer>) {
+	const dsk = AtemStateUtil.getDownstreamKeyer(state as AtemState, index)
 	dsk.properties = jsonClone({
 		...Defaults.Video.DownstreamerKeyerProperties,
 		...props,

--- a/src/resolvers/__tests__/mixEffect.spec.ts
+++ b/src/resolvers/__tests__/mixEffect.spec.ts
@@ -1,5 +1,7 @@
 import * as ME from '../mixEffect'
-import { Enums, MixEffect, ExtendedMixEffect, Defaults } from '../../'
+import * as Enums from '../../enums'
+import { MixEffect, ExtendedMixEffect } from '../../state'
+import * as Defaults from '../../defaults'
 import { Commands, Enums as AtemEnums, AtemStateUtil, VideoState } from 'atem-connection'
 import { jsonClone } from '../../util'
 

--- a/src/resolvers/__tests__/supersourceBox.spec.ts
+++ b/src/resolvers/__tests__/supersourceBox.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import * as supersource from '../supersource'
-import { Defaults } from '../../'
+import * as Defaults from '../../defaults'
 import { Commands, Enums, AtemStateUtil } from 'atem-connection'
 import { jsonClone } from '../../util'
 

--- a/src/resolvers/audio.ts
+++ b/src/resolvers/audio.ts
@@ -1,24 +1,26 @@
 import { Commands as AtemCommands, Commands } from 'atem-connection'
 import { State as StateObject } from '../'
-import { getAllKeysNumber, diffObject } from '../util'
+import { getAllKeysNumber, diffObject, fillDefaults } from '../util'
 import * as Defaults from '../defaults'
+import { PartialDeep } from 'type-fest'
 
-export function resolveAudioState(oldState: StateObject, newState: StateObject): Array<Commands.ISerializableCommand> {
+export function resolveAudioState(
+	oldState: PartialDeep<StateObject>,
+	newState: PartialDeep<StateObject>
+): Array<Commands.ISerializableCommand> {
 	const commands: Array<AtemCommands.ISerializableCommand> = []
 	if (!newState.audio) return commands
 
 	commands.push(...resolveAudioMixerInputsState(oldState, newState))
 
-	if (oldState.audio) {
-		if (oldState.audio.master || newState.audio.master) {
-			const oldMaster = oldState.audio.master || Defaults.Audio.Master
-			const newMaster = newState.audio.master || Defaults.Audio.Master
+	if (oldState.audio || newState.audio) {
+		const oldMaster = fillDefaults(Defaults.Audio.Master, oldState.audio?.master)
+		const newMaster = fillDefaults(Defaults.Audio.Master, newState.audio?.master)
 
-			const props = diffObject(oldMaster, newMaster)
-			const command = new Commands.AudioMixerMasterCommand()
-			if (command.updateProps(props)) {
-				commands.push(command)
-			}
+		const props = diffObject(oldMaster, newMaster)
+		const command = new Commands.AudioMixerMasterCommand()
+		if (command.updateProps(props)) {
+			commands.push(command)
 		}
 	}
 
@@ -26,15 +28,15 @@ export function resolveAudioState(oldState: StateObject, newState: StateObject):
 }
 
 export function resolveAudioMixerInputsState(
-	oldState: StateObject,
-	newState: StateObject
+	oldState: PartialDeep<StateObject>,
+	newState: PartialDeep<StateObject>
 ): Array<Commands.ISerializableCommand> {
 	const commands: Array<AtemCommands.ISerializableCommand> = []
 
-	if (oldState.audio && newState.audio) {
-		for (const index of getAllKeysNumber(oldState.audio.channels, newState.audio.channels)) {
-			const oldChannel = oldState.audio.channels[index] || Defaults.Audio.Channel
-			const newChannel = newState.audio.channels[index] || Defaults.Audio.Channel
+	if (oldState.audio || newState.audio) {
+		for (const index of getAllKeysNumber(oldState.audio?.channels, newState.audio?.channels)) {
+			const oldChannel = fillDefaults(Defaults.Audio.Channel, oldState.audio?.channels?.[index])
+			const newChannel = fillDefaults(Defaults.Audio.Channel, newState.audio?.channels?.[index])
 
 			const props = diffObject(oldChannel, newChannel)
 			const command = new Commands.AudioMixerInputCommand(index)

--- a/src/resolvers/downstreamKeyer.ts
+++ b/src/resolvers/downstreamKeyer.ts
@@ -1,6 +1,7 @@
 import { Commands as AtemCommands, VideoState } from 'atem-connection'
 import { PartialDeep } from 'type-fest'
-import { State as StateObject, Defaults } from '../'
+import { State as StateObject } from '../state'
+import * as Defaults from '../defaults'
 import { getAllKeysNumber, diffObject, fillDefaults } from '../util'
 
 export function resolveDownstreamKeyerState(

--- a/src/resolvers/downstreamKeyer.ts
+++ b/src/resolvers/downstreamKeyer.ts
@@ -1,22 +1,23 @@
-import { Commands as AtemCommands, VideoState, AtemStateUtil, AtemState } from 'atem-connection'
+import { Commands as AtemCommands, VideoState } from 'atem-connection'
+import { PartialDeep } from 'type-fest'
 import { State as StateObject, Defaults } from '../'
-import { getAllKeysNumber, diffObject } from '../util'
+import { getAllKeysNumber, diffObject, fillDefaults } from '../util'
 
 export function resolveDownstreamKeyerState(
-	oldState: StateObject,
-	newState: StateObject
+	oldState: PartialDeep<StateObject>,
+	newState: PartialDeep<StateObject>
 ): Array<AtemCommands.ISerializableCommand> {
 	const commands: Array<AtemCommands.ISerializableCommand> = []
 
-	for (const index of getAllKeysNumber(oldState.video.downstreamKeyers, newState.video.downstreamKeyers)) {
-		const oldDsk = AtemStateUtil.getDownstreamKeyer(oldState as AtemState, index, true)
-		const newDsk = AtemStateUtil.getDownstreamKeyer(newState as AtemState, index, true)
+	for (const index of getAllKeysNumber(oldState.video?.downstreamKeyers, newState.video?.downstreamKeyers)) {
+		const oldDsk = fillDefaults(Defaults.Video.DownstreamKeyer, oldState.video?.downstreamKeyers?.[index])
+		const newDsk = fillDefaults(Defaults.Video.DownstreamKeyer, newState.video?.downstreamKeyers?.[index])
 
 		commands.push(...resolveDownstreamKeyerPropertiesState(index, oldDsk, newDsk))
 		commands.push(...resolveDownstreamKeyerMaskState(index, oldDsk, newDsk))
 
-		const oldSources = oldDsk.sources || Defaults.Video.DownstreamerKeyerSources
-		const newSources = newDsk.sources || Defaults.Video.DownstreamerKeyerSources
+		const oldSources = oldDsk.sources ?? Defaults.Video.DownstreamerKeyerSources
+		const newSources = newDsk.sources ?? Defaults.Video.DownstreamerKeyerSources
 
 		if (oldSources.fillSource !== newSources.fillSource) {
 			commands.push(new AtemCommands.DownstreamKeyFillSourceCommand(index, newSources.fillSource))
@@ -44,8 +45,8 @@ export function resolveDownstreamKeyerPropertiesState(
 
 	if (!oldDsk.properties && !newDsk.properties) return commands
 
-	const oldProps = oldDsk.properties || Defaults.Video.DownstreamerKeyerProperties
-	const newProps = newDsk.properties || Defaults.Video.DownstreamerKeyerProperties
+	const oldProps = fillDefaults(Defaults.Video.DownstreamerKeyerProperties, oldDsk.properties)
+	const newProps = fillDefaults(Defaults.Video.DownstreamerKeyerProperties, newDsk.properties)
 
 	const props = diffObject(oldProps, newProps)
 	const command = new AtemCommands.DownstreamKeyGeneralCommand(index)
@@ -73,8 +74,8 @@ export function resolveDownstreamKeyerMaskState(
 
 	if (!oldDsk.properties && !newDsk.properties) return commands
 
-	const oldProps = oldDsk.properties || Defaults.Video.DownstreamerKeyerProperties
-	const newProps = newDsk.properties || Defaults.Video.DownstreamerKeyerProperties
+	const oldProps = fillDefaults(Defaults.Video.DownstreamerKeyerProperties, oldDsk.properties)
+	const newProps = fillDefaults(Defaults.Video.DownstreamerKeyerProperties, newDsk.properties)
 
 	const props = diffObject(oldProps.mask, newProps.mask)
 	const command = new AtemCommands.DownstreamKeyMaskCommand(index)

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -8,10 +8,11 @@ import { resolveAudioState } from './audio'
 import { resolveMacroPlayerState } from './macro'
 import { getAllKeysNumber } from '../util'
 import { resolveMediaPlayerState } from './media'
+import { PartialDeep } from 'type-fest'
 
 export function videoState(
-	oldState: StateObject,
-	newState: StateObject,
+	oldState: PartialDeep<StateObject>,
+	newState: PartialDeep<StateObject>,
 	version: Enums.ProtocolVersion
 ): Array<AtemCommands.ISerializableCommand> {
 	const commands: Array<AtemCommands.ISerializableCommand> = []
@@ -24,9 +25,9 @@ export function videoState(
 	commands.push(...resolveMediaPlayerState(oldState, newState))
 
 	// resolve auxilliaries:
-	for (const index of getAllKeysNumber(oldState.video.auxilliaries, newState.video.auxilliaries)) {
-		const oldSource = oldState.video.auxilliaries[index] || 0
-		const newSource = newState.video.auxilliaries[index] || 0
+	for (const index of getAllKeysNumber(oldState.video?.auxilliaries, newState.video?.auxilliaries)) {
+		const oldSource = oldState.video?.auxilliaries?.[index] ?? 0
+		const newSource = newState.video?.auxilliaries?.[index] ?? 0
 
 		if (oldSource !== newSource) {
 			commands.push(new AtemCommands.AuxSourceCommand(index, newSource))

--- a/src/resolvers/macro.ts
+++ b/src/resolvers/macro.ts
@@ -1,6 +1,6 @@
 import { Commands as AtemCommands, Enums as AtemEnums } from 'atem-connection'
 import { PartialDeep } from 'type-fest'
-import { State as StateObject } from '../'
+import { State as StateObject } from '../state'
 
 export function resolveMacroPlayerState(
 	oldState: PartialDeep<StateObject>,

--- a/src/resolvers/macro.ts
+++ b/src/resolvers/macro.ts
@@ -1,20 +1,22 @@
 import { Commands as AtemCommands, Enums as AtemEnums } from 'atem-connection'
+import { PartialDeep } from 'type-fest'
 import { State as StateObject } from '../'
 
 export function resolveMacroPlayerState(
-	oldState: StateObject,
-	newState: StateObject
+	oldState: PartialDeep<StateObject>,
+	newState: PartialDeep<StateObject>
 ): Array<AtemCommands.ISerializableCommand> {
 	const commands: Array<AtemCommands.ISerializableCommand> = []
 
-	const newPlayer = newState.macro.macroPlayer
-	const oldPlayer = oldState.macro.macroPlayer
+	const newPlayer = newState.macro?.macroPlayer
+	const oldPlayer = oldState.macro?.macroPlayer
 
 	// TODO - fill out more
 
 	if (
 		newPlayer &&
 		newPlayer.isRunning &&
+		newPlayer.macroIndex !== undefined &&
 		(!oldPlayer || !oldPlayer.isRunning || oldPlayer.macroIndex !== newPlayer.macroIndex)
 	) {
 		commands.push(new AtemCommands.MacroActionCommand(newPlayer.macroIndex, AtemEnums.MacroAction.Run))

--- a/src/resolvers/media.ts
+++ b/src/resolvers/media.ts
@@ -11,7 +11,7 @@ export function resolveMediaPlayerState(
 
 	for (const index of getAllKeysNumber(oldState.media?.players, newState.media?.players)) {
 		const newPlayer = fillDefaults(Defaults.Video.MediaPlayer, newState.media?.players?.[index])
-		const oldPlayer = fillDefaults(Defaults.Video.MediaPlayer, newState.media?.players?.[index])
+		const oldPlayer = fillDefaults(Defaults.Video.MediaPlayer, oldState.media?.players?.[index])
 
 		const props = diffObject<MediaState.MediaPlayer>(oldPlayer, newPlayer)
 		const command = new AtemCommands.MediaPlayerStatusCommand(index)

--- a/src/resolvers/media.ts
+++ b/src/resolvers/media.ts
@@ -1,6 +1,7 @@
 import { Commands as AtemCommands, MediaState } from 'atem-connection'
 import { PartialDeep } from 'type-fest'
-import { Defaults, State as StateObject } from '../'
+import { State as StateObject } from '../state'
+import * as Defaults from '../defaults'
 import { diffObject, fillDefaults, getAllKeysNumber } from '../util'
 
 export function resolveMediaPlayerState(

--- a/src/resolvers/media.ts
+++ b/src/resolvers/media.ts
@@ -1,16 +1,17 @@
-import { Commands as AtemCommands, AtemStateUtil, MediaState, AtemState } from 'atem-connection'
-import { State as StateObject } from '../'
-import { diffObject, getAllKeysNumber } from '../util'
+import { Commands as AtemCommands, MediaState } from 'atem-connection'
+import { PartialDeep } from 'type-fest'
+import { Defaults, State as StateObject } from '../'
+import { diffObject, fillDefaults, getAllKeysNumber } from '../util'
 
 export function resolveMediaPlayerState(
-	oldState: StateObject,
-	newState: StateObject
+	oldState: PartialDeep<StateObject>,
+	newState: PartialDeep<StateObject>
 ): Array<AtemCommands.ISerializableCommand> {
 	const commands: Array<AtemCommands.ISerializableCommand> = []
 
-	for (const index of getAllKeysNumber(oldState.media.players, newState.media.players)) {
-		const newPlayer = AtemStateUtil.getMediaPlayer(newState as AtemState, index, true)
-		const oldPlayer = AtemStateUtil.getMediaPlayer(oldState as AtemState, index, true)
+	for (const index of getAllKeysNumber(oldState.media?.players, newState.media?.players)) {
+		const newPlayer = fillDefaults(Defaults.Video.MediaPlayer, newState.media?.players?.[index])
+		const oldPlayer = fillDefaults(Defaults.Video.MediaPlayer, newState.media?.players?.[index])
 
 		const props = diffObject<MediaState.MediaPlayer>(oldPlayer, newPlayer)
 		const command = new AtemCommands.MediaPlayerStatusCommand(index)

--- a/src/resolvers/mixEffect.ts
+++ b/src/resolvers/mixEffect.ts
@@ -1,5 +1,7 @@
 import { Commands as AtemCommands, Enums as ConnectionEnums, VideoState } from 'atem-connection'
-import { Enums, State as StateObject, Defaults } from '../'
+import { State as StateObject } from '../state'
+import * as Defaults from '../defaults'
+import * as Enums from '../enums'
 import { getAllKeysNumber, diffObject, fillDefaults } from '../util'
 import { ExtendedMixEffect } from '../state'
 

--- a/src/resolvers/mixEffect.ts
+++ b/src/resolvers/mixEffect.ts
@@ -1,27 +1,22 @@
-import {
-	Commands as AtemCommands,
-	Enums as ConnectionEnums,
-	AtemStateUtil,
-	VideoState,
-	AtemState,
-} from 'atem-connection'
+import { Commands as AtemCommands, Enums as ConnectionEnums, AtemStateUtil, VideoState } from 'atem-connection'
 import { Enums, State as StateObject, Defaults } from '../'
 import { getAllKeysNumber, diffObject } from '../util'
 import { ExtendedMixEffect } from '../state'
 
 import { resolveUpstreamKeyerState } from './upstreamKeyers'
+import { PartialDeep } from 'type-fest'
 
 export function resolveMixEffectsState(
-	oldState: StateObject,
-	newState: StateObject
+	oldState: PartialDeep<StateObject>,
+	newState: PartialDeep<StateObject>
 ): Array<AtemCommands.ISerializableCommand> {
 	const commands: Array<AtemCommands.ISerializableCommand> = []
 
-	for (const mixEffectId of getAllKeysNumber(oldState.video.mixEffects, newState.video.mixEffects)) {
-		const oldMixEffect = AtemStateUtil.getMixEffect(oldState as AtemState, mixEffectId, true) as
+	for (const mixEffectId of getAllKeysNumber(oldState.video?.mixEffects, newState.video?.mixEffects)) {
+		const oldMixEffect = AtemStateUtil.getMixEffect(oldState, mixEffectId, true) as
 			| ExtendedMixEffect
 			| VideoState.MixEffect
-		const newMixEffect = AtemStateUtil.getMixEffect(newState as AtemState, mixEffectId, true) as
+		const newMixEffect = AtemStateUtil.getMixEffect(newState, mixEffectId, true) as
 			| ExtendedMixEffect
 			| VideoState.MixEffect
 
@@ -119,8 +114,8 @@ export function resolveTransitionSettingsState(
 
 	if (newTransitionSettings.dip || oldTransitionSettings.dip) {
 		const dipProperties = diffObject(
-			oldTransitionSettings.dip || Defaults.Video.DipTransitionSettings,
-			newTransitionSettings.dip || Defaults.Video.DipTransitionSettings
+			oldTransitionSettings.dip _||_ Defaults.Video.DipTransitionSettings,
+			newTransitionSettings.dip _||_ Defaults.Video.DipTransitionSettings
 		)
 		const command = new AtemCommands.TransitionDipCommand(mixEffectId)
 		if (command.updateProps(dipProperties)) {
@@ -130,8 +125,8 @@ export function resolveTransitionSettingsState(
 
 	if (newTransitionSettings.DVE || oldTransitionSettings.DVE) {
 		const dveProperties = diffObject(
-			oldTransitionSettings.DVE || Defaults.Video.DVETransitionSettings,
-			newTransitionSettings.DVE || Defaults.Video.DVETransitionSettings
+			oldTransitionSettings.DVE _||_ Defaults.Video.DVETransitionSettings,
+			newTransitionSettings.DVE _||_ Defaults.Video.DVETransitionSettings
 		)
 		const command = new AtemCommands.TransitionDVECommand(mixEffectId)
 		if (command.updateProps(dveProperties)) {
@@ -140,8 +135,8 @@ export function resolveTransitionSettingsState(
 	}
 
 	if (newTransitionSettings.mix || oldTransitionSettings.mix) {
-		const oldProps = oldTransitionSettings.mix || Defaults.Video.MixTransitionSettings
-		const newProps = newTransitionSettings.mix || Defaults.Video.MixTransitionSettings
+		const oldProps = oldTransitionSettings.mix _||_ Defaults.Video.MixTransitionSettings
+		const newProps = newTransitionSettings.mix _||_ Defaults.Video.MixTransitionSettings
 		if (oldProps.rate !== newProps.rate) {
 			commands.push(new AtemCommands.TransitionMixCommand(mixEffectId, newProps.rate))
 		}
@@ -149,8 +144,8 @@ export function resolveTransitionSettingsState(
 
 	if (newTransitionSettings.stinger || oldTransitionSettings.stinger) {
 		const stingerProperties = diffObject(
-			oldTransitionSettings.stinger || Defaults.Video.StingerTransitionSettings,
-			newTransitionSettings.stinger || Defaults.Video.StingerTransitionSettings
+			oldTransitionSettings.stinger _||_ Defaults.Video.StingerTransitionSettings,
+			newTransitionSettings.stinger _||_ Defaults.Video.StingerTransitionSettings
 		)
 		const command = new AtemCommands.TransitionStingerCommand(mixEffectId)
 		if (command.updateProps(stingerProperties)) {
@@ -160,8 +155,8 @@ export function resolveTransitionSettingsState(
 
 	if (newTransitionSettings.wipe || oldTransitionSettings.wipe) {
 		const wipeProperties = diffObject(
-			oldTransitionSettings.wipe || Defaults.Video.WipeTransitionSettings,
-			newTransitionSettings.wipe || Defaults.Video.WipeTransitionSettings
+			oldTransitionSettings.wipe _||_ Defaults.Video.WipeTransitionSettings,
+			newTransitionSettings.wipe _||_ Defaults.Video.WipeTransitionSettings
 		)
 		const command = new AtemCommands.TransitionWipeCommand(mixEffectId)
 		if (command.updateProps(wipeProperties)) {

--- a/src/resolvers/mixEffect.ts
+++ b/src/resolvers/mixEffect.ts
@@ -22,7 +22,7 @@ export function resolveMixEffectsState(
 		commands.push(...resolveTransitionSettingsState(mixEffectId, oldMixEffect, newMixEffect))
 		commands.push(...resolveUpstreamKeyerState(mixEffectId, oldMixEffect, newMixEffect))
 
-		let oldMEInput = 0
+		let oldMEInput = Defaults.Video.defaultInput
 		let oldMeTransition: Enums.TransitionStyle = Defaults.Video.TransitionProperties.style
 		if (oldMixEffect) {
 			if ('input' in oldMixEffect || 'transition' in oldMixEffect) {
@@ -35,13 +35,12 @@ export function resolveMixEffectsState(
 				}
 			}
 		}
-		// const oldMEInput = 'input' in oldMixEffect2 ? oldMixEffect2.input : oldMixEffect2.programInput
-		// const oldMeTransition =
-		// 	'transition' in oldMixEffect ? oldMixEffect.transition : oldMixEffect.transitionProperties.style
 
 		if (newMixEffect && 'input' in newMixEffect && 'transition' in newMixEffect) {
 			if (newMixEffect.input !== oldMEInput || newMixEffect.transition === Enums.TransitionStyle.DUMMY) {
-				commands.push(new AtemCommands.PreviewInputCommand(mixEffectId, newMixEffect.input ?? 0))
+				commands.push(
+					new AtemCommands.PreviewInputCommand(mixEffectId, newMixEffect.input ?? Defaults.Video.defaultInput)
+				)
 
 				if (newMixEffect.transition === Enums.TransitionStyle.CUT) {
 					commands.push(new AtemCommands.CutCommand(mixEffectId))
@@ -60,15 +59,18 @@ export function resolveMixEffectsState(
 				}
 			}
 		} else if ((!oldMixEffect || 'previewInput' in oldMixEffect) && (!newMixEffect || 'previewInput' in newMixEffect)) {
-			if (oldMixEffect?.previewInput !== newMixEffect?.previewInput) {
-				commands.push(new AtemCommands.PreviewInputCommand(mixEffectId, newMixEffect?.previewInput ?? 0))
+			const oldMePreviewInput = oldMixEffect?.previewInput ?? Defaults.Video.defaultInput
+			const newMePreviewInput = newMixEffect?.previewInput ?? Defaults.Video.defaultInput
+			if (oldMePreviewInput !== newMePreviewInput) {
+				commands.push(new AtemCommands.PreviewInputCommand(mixEffectId, newMePreviewInput))
 			}
-			if (oldMEInput !== newMixEffect?.programInput) {
+			const newMeProgramInput = newMixEffect?.programInput ?? Defaults.Video.defaultInput
+			if (oldMEInput !== newMeProgramInput) {
 				// @todo: check if we need to use the cut command?
 				// use cut command if:
 				//   DSK is tied
 				//   Upstream Keyer is set for next transition
-				commands.push(new AtemCommands.ProgramInputCommand(mixEffectId, newMixEffect?.programInput ?? 0))
+				commands.push(new AtemCommands.ProgramInputCommand(mixEffectId, newMeProgramInput))
 			}
 		}
 

--- a/src/resolvers/mixEffect.ts
+++ b/src/resolvers/mixEffect.ts
@@ -82,7 +82,7 @@ export function resolveMixEffectsState(
 			commands.push(new AtemCommands.TransitionPositionCommand(mixEffectId, 10000)) // finish transition
 		}
 
-		if (oldMixEffect?.transitionPreview ?? false !== newMixEffect?.transitionPreview ?? false) {
+		if ((oldMixEffect?.transitionPreview ?? false) !== (newMixEffect?.transitionPreview ?? false)) {
 			commands.push(new AtemCommands.PreviewTransitionCommand(mixEffectId, newMixEffect?.transitionPreview ?? false))
 		}
 

--- a/src/resolvers/supersource.ts
+++ b/src/resolvers/supersource.ts
@@ -1,5 +1,5 @@
 import { Commands as AtemCommands, VideoState, Enums } from 'atem-connection'
-import { State as StateObject } from '..'
+import { State as StateObject } from '../state'
 import { diffObject, fillDefaults, getAllKeysNumber } from '../util'
 import * as Defaults from '../defaults'
 import { PartialDeep } from 'type-fest'

--- a/src/resolvers/upstreamKeyers/__tests__/chromaKeyer.spec.ts
+++ b/src/resolvers/upstreamKeyers/__tests__/chromaKeyer.spec.ts
@@ -1,5 +1,5 @@
 import * as CK from '../chromaKeyer'
-import { Defaults } from '../../../'
+import * as Defaults from '../../../defaults'
 import { Commands, AtemStateUtil } from 'atem-connection'
 import { jsonClone } from '../../../util'
 

--- a/src/resolvers/upstreamKeyers/__tests__/dveKeyer.spec.ts
+++ b/src/resolvers/upstreamKeyers/__tests__/dveKeyer.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import * as DVE from '../dveKeyer'
-import { Defaults } from '../../../'
+import * as Defaults from '../../../defaults'
 import { Commands, Enums, AtemStateUtil } from 'atem-connection'
 import { jsonClone } from '../../../util'
 

--- a/src/resolvers/upstreamKeyers/__tests__/lumaKeyer.spec.ts
+++ b/src/resolvers/upstreamKeyers/__tests__/lumaKeyer.spec.ts
@@ -1,5 +1,5 @@
 import * as LK from '../lumaKeyer'
-import { Defaults } from '../../../'
+import * as Defaults from '../../../defaults'
 import { Commands, AtemStateUtil } from 'atem-connection'
 import { jsonClone } from '../../../util'
 

--- a/src/resolvers/upstreamKeyers/__tests__/patternKeyer.spec.ts
+++ b/src/resolvers/upstreamKeyers/__tests__/patternKeyer.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import * as PatternKeyer from '../patternKeyer'
-import { Defaults } from '../../../'
+import * as Defaults from '../../../defaults'
 import { Commands, Enums, AtemStateUtil } from 'atem-connection'
 import { jsonClone } from '../../../util'
 

--- a/src/resolvers/upstreamKeyers/__tests__/upstreamKeyer.spec.ts
+++ b/src/resolvers/upstreamKeyers/__tests__/upstreamKeyer.spec.ts
@@ -1,5 +1,5 @@
 import * as USK from '../index'
-import { Defaults } from '../../../'
+import * as Defaults from '../../../defaults'
 import { Commands, Enums, AtemStateUtil } from 'atem-connection'
 
 const STATE1 = AtemStateUtil.Create()

--- a/src/resolvers/upstreamKeyers/chromaKeyer.ts
+++ b/src/resolvers/upstreamKeyers/chromaKeyer.ts
@@ -1,6 +1,6 @@
 import { Commands as AtemCommands, VideoState } from 'atem-connection'
 import { diffObject, fillDefaults } from '../../util'
-import { Defaults } from '../..'
+import * as Defaults from '../../defaults'
 import { PartialDeep } from 'type-fest'
 
 export function resolveChromaKeyerState(

--- a/src/resolvers/upstreamKeyers/chromaKeyer.ts
+++ b/src/resolvers/upstreamKeyers/chromaKeyer.ts
@@ -12,8 +12,8 @@ export function resolveChromaKeyerState(
 
 	if (!oldKeyer.chromaSettings && !newKeyer.chromaSettings) return commands
 
-	const oldChromaKeyer = oldKeyer.chromaSettings || Defaults.Video.UpstreamKeyerChromaSettings
-	const newChromaKeyer = newKeyer.chromaSettings || Defaults.Video.UpstreamKeyerChromaSettings
+	const oldChromaKeyer = oldKeyer.chromaSettings _||_ Defaults.Video.UpstreamKeyerChromaSettings
+	const newChromaKeyer = newKeyer.chromaSettings _||_ Defaults.Video.UpstreamKeyerChromaSettings
 
 	const props = diffObject(oldChromaKeyer, newChromaKeyer)
 	const command = new AtemCommands.MixEffectKeyChromaCommand(mixEffectId, upstreamKeyerId)

--- a/src/resolvers/upstreamKeyers/chromaKeyer.ts
+++ b/src/resolvers/upstreamKeyers/chromaKeyer.ts
@@ -1,19 +1,20 @@
 import { Commands as AtemCommands, VideoState } from 'atem-connection'
-import { diffObject } from '../../util'
+import { diffObject, fillDefaults } from '../../util'
 import { Defaults } from '../..'
+import { PartialDeep } from 'type-fest'
 
 export function resolveChromaKeyerState(
 	mixEffectId: number,
 	upstreamKeyerId: number,
-	oldKeyer: VideoState.USK.UpstreamKeyer,
-	newKeyer: VideoState.USK.UpstreamKeyer
+	oldKeyer: PartialDeep<VideoState.USK.UpstreamKeyer>,
+	newKeyer: PartialDeep<VideoState.USK.UpstreamKeyer>
 ): Array<AtemCommands.ISerializableCommand> {
 	const commands: Array<AtemCommands.ISerializableCommand> = []
 
 	if (!oldKeyer.chromaSettings && !newKeyer.chromaSettings) return commands
 
-	const oldChromaKeyer = oldKeyer.chromaSettings _||_ Defaults.Video.UpstreamKeyerChromaSettings
-	const newChromaKeyer = newKeyer.chromaSettings _||_ Defaults.Video.UpstreamKeyerChromaSettings
+	const oldChromaKeyer = fillDefaults(Defaults.Video.UpstreamKeyerChromaSettings, oldKeyer.chromaSettings)
+	const newChromaKeyer = fillDefaults(Defaults.Video.UpstreamKeyerChromaSettings, newKeyer.chromaSettings)
 
 	const props = diffObject(oldChromaKeyer, newChromaKeyer)
 	const command = new AtemCommands.MixEffectKeyChromaCommand(mixEffectId, upstreamKeyerId)

--- a/src/resolvers/upstreamKeyers/dveKeyer.ts
+++ b/src/resolvers/upstreamKeyers/dveKeyer.ts
@@ -1,6 +1,6 @@
 import { Commands as AtemCommands, VideoState } from 'atem-connection'
 import { diffObject, fillDefaults } from '../../util'
-import { Defaults } from '../..'
+import * as Defaults from '../../defaults'
 import { PartialDeep } from 'type-fest'
 
 export function resolveDVEKeyerState(

--- a/src/resolvers/upstreamKeyers/dveKeyer.ts
+++ b/src/resolvers/upstreamKeyers/dveKeyer.ts
@@ -12,8 +12,8 @@ export function resolveDVEKeyerState(
 
 	if (!oldKeyer.dveSettings && !newKeyer.dveSettings) return commands
 
-	const oldDVEKeyer = oldKeyer.dveSettings || Defaults.Video.UpstreamKeyerDVESettings
-	const newDVEKeyer = newKeyer.dveSettings || Defaults.Video.UpstreamKeyerDVESettings
+	const oldDVEKeyer = oldKeyer.dveSettings _||_ Defaults.Video.UpstreamKeyerDVESettings
+	const newDVEKeyer = newKeyer.dveSettings _||_ Defaults.Video.UpstreamKeyerDVESettings
 
 	const props = diffObject(oldDVEKeyer, newDVEKeyer)
 	const command = new AtemCommands.MixEffectKeyDVECommand(mixEffectId, upstreamKeyerId)

--- a/src/resolvers/upstreamKeyers/dveKeyer.ts
+++ b/src/resolvers/upstreamKeyers/dveKeyer.ts
@@ -1,19 +1,20 @@
 import { Commands as AtemCommands, VideoState } from 'atem-connection'
-import { diffObject } from '../../util'
+import { diffObject, fillDefaults } from '../../util'
 import { Defaults } from '../..'
+import { PartialDeep } from 'type-fest'
 
 export function resolveDVEKeyerState(
 	mixEffectId: number,
 	upstreamKeyerId: number,
-	oldKeyer: VideoState.USK.UpstreamKeyer,
-	newKeyer: VideoState.USK.UpstreamKeyer
+	oldKeyer: PartialDeep<VideoState.USK.UpstreamKeyer>,
+	newKeyer: PartialDeep<VideoState.USK.UpstreamKeyer>
 ): Array<AtemCommands.ISerializableCommand> {
 	const commands: Array<AtemCommands.ISerializableCommand> = []
 
 	if (!oldKeyer.dveSettings && !newKeyer.dveSettings) return commands
 
-	const oldDVEKeyer = oldKeyer.dveSettings _||_ Defaults.Video.UpstreamKeyerDVESettings
-	const newDVEKeyer = newKeyer.dveSettings _||_ Defaults.Video.UpstreamKeyerDVESettings
+	const oldDVEKeyer = fillDefaults(Defaults.Video.UpstreamKeyerDVESettings, oldKeyer.dveSettings)
+	const newDVEKeyer = fillDefaults(Defaults.Video.UpstreamKeyerDVESettings, newKeyer.dveSettings)
 
 	const props = diffObject(oldDVEKeyer, newDVEKeyer)
 	const command = new AtemCommands.MixEffectKeyDVECommand(mixEffectId, upstreamKeyerId)

--- a/src/resolvers/upstreamKeyers/lumaKeyer.ts
+++ b/src/resolvers/upstreamKeyers/lumaKeyer.ts
@@ -1,19 +1,20 @@
 import { Commands as AtemCommands, VideoState } from 'atem-connection'
-import { diffObject } from '../../util'
+import { diffObject, fillDefaults } from '../../util'
 import { Defaults } from '../..'
+import { PartialDeep } from 'type-fest'
 
 export function resolveLumaKeyerState(
 	mixEffectId: number,
 	upstreamKeyerId: number,
-	oldKeyer: VideoState.USK.UpstreamKeyer,
-	newKeyer: VideoState.USK.UpstreamKeyer
+	oldKeyer: PartialDeep<VideoState.USK.UpstreamKeyer>,
+	newKeyer: PartialDeep<VideoState.USK.UpstreamKeyer>
 ): Array<AtemCommands.ISerializableCommand> {
 	const commands: Array<AtemCommands.ISerializableCommand> = []
 
 	if (!oldKeyer.lumaSettings && !newKeyer.lumaSettings) return commands
 
-	const oldLumaKeyer = oldKeyer.lumaSettings _||_ Defaults.Video.UpstreamKeyerLumaSettings
-	const newLumaKeyer = newKeyer.lumaSettings _||_ Defaults.Video.UpstreamKeyerLumaSettings
+	const oldLumaKeyer = fillDefaults(Defaults.Video.UpstreamKeyerLumaSettings, oldKeyer.lumaSettings)
+	const newLumaKeyer = fillDefaults(Defaults.Video.UpstreamKeyerLumaSettings, newKeyer.lumaSettings)
 
 	const props = diffObject(oldLumaKeyer, newLumaKeyer)
 	const command = new AtemCommands.MixEffectKeyLumaCommand(mixEffectId, upstreamKeyerId)

--- a/src/resolvers/upstreamKeyers/lumaKeyer.ts
+++ b/src/resolvers/upstreamKeyers/lumaKeyer.ts
@@ -1,6 +1,6 @@
 import { Commands as AtemCommands, VideoState } from 'atem-connection'
 import { diffObject, fillDefaults } from '../../util'
-import { Defaults } from '../..'
+import * as Defaults from '../../defaults'
 import { PartialDeep } from 'type-fest'
 
 export function resolveLumaKeyerState(

--- a/src/resolvers/upstreamKeyers/lumaKeyer.ts
+++ b/src/resolvers/upstreamKeyers/lumaKeyer.ts
@@ -12,8 +12,8 @@ export function resolveLumaKeyerState(
 
 	if (!oldKeyer.lumaSettings && !newKeyer.lumaSettings) return commands
 
-	const oldLumaKeyer = oldKeyer.lumaSettings || Defaults.Video.UpstreamKeyerLumaSettings
-	const newLumaKeyer = newKeyer.lumaSettings || Defaults.Video.UpstreamKeyerLumaSettings
+	const oldLumaKeyer = oldKeyer.lumaSettings _||_ Defaults.Video.UpstreamKeyerLumaSettings
+	const newLumaKeyer = newKeyer.lumaSettings _||_ Defaults.Video.UpstreamKeyerLumaSettings
 
 	const props = diffObject(oldLumaKeyer, newLumaKeyer)
 	const command = new AtemCommands.MixEffectKeyLumaCommand(mixEffectId, upstreamKeyerId)

--- a/src/resolvers/upstreamKeyers/patternKeyer.ts
+++ b/src/resolvers/upstreamKeyers/patternKeyer.ts
@@ -1,6 +1,6 @@
 import { Commands as AtemCommands, VideoState } from 'atem-connection'
 import { diffObject, fillDefaults } from '../../util'
-import { Defaults } from '../..'
+import * as Defaults from '../../defaults'
 import { PartialDeep } from 'type-fest'
 
 export function resolvePatternKeyerState(

--- a/src/resolvers/upstreamKeyers/patternKeyer.ts
+++ b/src/resolvers/upstreamKeyers/patternKeyer.ts
@@ -12,8 +12,8 @@ export function resolvePatternKeyerState(
 
 	if (!oldKeyer.patternSettings && !newKeyer.patternSettings) return commands
 
-	const oldPatternKeyer = oldKeyer.patternSettings || Defaults.Video.UpstreamKeyerPatternSettings
-	const newPatternKeyer = newKeyer.patternSettings || Defaults.Video.UpstreamKeyerPatternSettings
+	const oldPatternKeyer = oldKeyer.patternSettings _||_ Defaults.Video.UpstreamKeyerPatternSettings
+	const newPatternKeyer = newKeyer.patternSettings _||_ Defaults.Video.UpstreamKeyerPatternSettings
 
 	const props = diffObject(oldPatternKeyer, newPatternKeyer)
 	if (props && oldPatternKeyer.style !== newPatternKeyer.style) {

--- a/src/resolvers/upstreamKeyers/patternKeyer.ts
+++ b/src/resolvers/upstreamKeyers/patternKeyer.ts
@@ -1,19 +1,20 @@
 import { Commands as AtemCommands, VideoState } from 'atem-connection'
-import { diffObject } from '../../util'
+import { diffObject, fillDefaults } from '../../util'
 import { Defaults } from '../..'
+import { PartialDeep } from 'type-fest'
 
 export function resolvePatternKeyerState(
 	mixEffectId: number,
 	upstreamKeyerId: number,
-	oldKeyer: VideoState.USK.UpstreamKeyer,
-	newKeyer: VideoState.USK.UpstreamKeyer
+	oldKeyer: PartialDeep<VideoState.USK.UpstreamKeyer>,
+	newKeyer: PartialDeep<VideoState.USK.UpstreamKeyer>
 ): Array<AtemCommands.ISerializableCommand> {
 	const commands: Array<AtemCommands.ISerializableCommand> = []
 
 	if (!oldKeyer.patternSettings && !newKeyer.patternSettings) return commands
 
-	const oldPatternKeyer = oldKeyer.patternSettings _||_ Defaults.Video.UpstreamKeyerPatternSettings
-	const newPatternKeyer = newKeyer.patternSettings _||_ Defaults.Video.UpstreamKeyerPatternSettings
+	const oldPatternKeyer = fillDefaults(Defaults.Video.UpstreamKeyerPatternSettings, oldKeyer.patternSettings)
+	const newPatternKeyer = fillDefaults(Defaults.Video.UpstreamKeyerPatternSettings, newKeyer.patternSettings)
 
 	const props = diffObject(oldPatternKeyer, newPatternKeyer)
 	if (props && oldPatternKeyer.style !== newPatternKeyer.style) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -38,5 +38,5 @@ export function jsonClone<T>(src: T): T {
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export function fillDefaults<T extends object>(defaults: T, val: PartialDeep<T> | PartialObjectDeep<T> | undefined): T {
-	return deepMerge(defaults, val as Partial<T>)
+	return deepMerge(defaults, (val ?? {}) as Partial<T>)
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,8 @@
-export function diffObject<T>(oldObj: T, newObj: T): Partial<T> {
+import { PartialDeep } from 'type-fest'
+import * as deepMerge from 'deepmerge'
+import { PartialObjectDeep } from 'type-fest/source/partial-deep'
+
+export function diffObject<T>(oldObj: Partial<T>, newObj: Partial<T>): Partial<T> {
 	const diff: Partial<T> = {}
 	for (const key in newObj) {
 		const typedKey = key as keyof T
@@ -21,13 +25,18 @@ export function getAllKeysString<V>(oldObj: { [key: string]: V }, newObj: { [key
 	return rawKeys.filter((v, i) => keyIsValid(v, oldObj, newObj) && rawKeys.indexOf(v) === i)
 }
 export function getAllKeysNumber<V>(
-	oldObj: { [key: number]: V } | Array<V>,
-	newObj: { [key: number]: V } | Array<V>
+	oldObj: { [key: number]: V } | Array<V> | undefined,
+	newObj: { [key: number]: V } | Array<V> | undefined
 ): number[] {
-	const rawKeys = Object.keys(oldObj).concat(Object.keys(newObj))
+	const rawKeys = Object.keys(oldObj ?? []).concat(Object.keys(newObj ?? []))
 	return rawKeys.filter((v, i) => keyIsValid(v, oldObj, newObj) && rawKeys.indexOf(v) === i).map((v) => parseInt(v, 10))
 }
 
 export function jsonClone<T>(src: T): T {
 	return JSON.parse(JSON.stringify(src))
+}
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function fillDefaults<T extends object>(defaults: T, val: PartialDeep<T> | PartialObjectDeep<T> | undefined): T {
+	return deepMerge(defaults, val as Partial<T>)
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -20,15 +20,22 @@ function keyIsValid(key: string, oldObj: any, newObj: any) {
 	return (oldVal !== undefined && oldVal !== null) || (newVal !== undefined && newVal !== null)
 }
 
-export function getAllKeysString<V>(oldObj: { [key: string]: V }, newObj: { [key: string]: V }): string[] {
+export function getAllKeysString<V>(
+	oldObj0: { [key: string]: V } | undefined,
+	newObj0: { [key: string]: V } | undefined
+): string[] {
+	const oldObj = oldObj0 ?? {}
+	const newObj = newObj0 ?? {}
 	const rawKeys = Object.keys(oldObj).concat(Object.keys(newObj))
 	return rawKeys.filter((v, i) => keyIsValid(v, oldObj, newObj) && rawKeys.indexOf(v) === i)
 }
 export function getAllKeysNumber<V>(
-	oldObj: { [key: number]: V } | Array<V> | undefined,
-	newObj: { [key: number]: V } | Array<V> | undefined
+	oldObj0: { [key: number]: V } | Array<V> | undefined,
+	newObj0: { [key: number]: V } | Array<V> | undefined
 ): number[] {
-	const rawKeys = Object.keys(oldObj ?? []).concat(Object.keys(newObj ?? []))
+	const oldObj = oldObj0 ?? []
+	const newObj = newObj0 ?? []
+	const rawKeys = Object.keys(oldObj).concat(Object.keys(newObj))
 	return rawKeys.filter((v, i) => keyIsValid(v, oldObj, newObj) && rawKeys.indexOf(v) === i).map((v) => parseInt(v, 10))
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5991,6 +5991,11 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+type-fest@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.0.2.tgz#3f9c39982859f385c77c38b7e5f1432b8a3661c6"
+  integrity sha512-a720oz3Kjbp3ll0zkeN9qjRhO7I34MKMhPGQiQJAmaZQZQ1lo+NWThK322f7sXV+kTg9B1Ybt16KgBXWgteT8w==
+
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix/Feature

* **What is the current behavior?** (You can also link to an open issue here)

The input states are expected to be 'complete' objects, according to the AtemState definition. If some expected keys are missing, that can result in TypeErrors being thrown.

* **What is the new behavior (if this is a feature change)?**

The library should be able to handle partial objects. When any keys are missing, the 'default' values should be used instead

* **Other information**:

This has not yet been tested, and could do with some work to test edge cases. It should be possible to automate this by taking complete state objects, deleting random keys and making sure a resolve doesnt error.
